### PR TITLE
Fix for incorrect calculation of betweenness in addNodeSize()

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,3 +3,4 @@
 ^img/bigNetwork\.png$
 ^README\.md$
 ^docs$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 inst/doc
+.Rproj.user

--- a/R/sigmaAttrs.R
+++ b/R/sigmaAttrs.R
@@ -121,7 +121,7 @@ addNodeSize <- function(sigmaObj, minSize = 1, maxSize = 3, sizeMetric = 'degree
     sigmaObj$x$options$minNodeSize <- minSize
     sigmaObj$x$options$maxNodeSize <- maxSize
   } else{
-    tmp_graph <- igraph::graph_from_data_frame(sigmaObj$x$graph$edges)
+    tmp_graph <- igraph::graph_from_data_frame(sigmaObj$x$graph)
     if(sizeMetric == 'degree'){
       nodes$size <- igraph::degree(tmp_graph)
     } else if(sizeMetric == 'closeness'){

--- a/R/sigmaAttrs.R
+++ b/R/sigmaAttrs.R
@@ -121,7 +121,8 @@ addNodeSize <- function(sigmaObj, minSize = 1, maxSize = 3, sizeMetric = 'degree
     sigmaObj$x$options$minNodeSize <- minSize
     sigmaObj$x$options$maxNodeSize <- maxSize
   } else{
-    tmp_graph <- igraph::graph_from_data_frame(sigmaObj$x$graph)
+    tmp_graph <- igraph::graph_from_data_frame(sigmaObj$x$graph$edges,
+                                               directed = FALSE)
     if(sizeMetric == 'degree'){
       nodes$size <- igraph::degree(tmp_graph)
     } else if(sizeMetric == 'closeness'){

--- a/sigmaNet.Rproj
+++ b/sigmaNet.Rproj
@@ -5,7 +5,12 @@ SaveWorkspace: No
 AlwaysSaveHistory: Default
 
 EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
 Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
 
 AutoAppendNewline: Yes
 StripTrailingWhitespace: Yes


### PR DESCRIPTION
### What my pull fixes (if applicable)
When `tmp_graph` is created in `addNodeSize()`, the default it to create a directed graph, this will change the values of some of the calculated metrics. 

### What my pull improves (if applicable)
Adding `directed = FALSE` so the previous and I think expected behaviour returns. 

### Confirmation that you have tested your code
```{r}
library(sigmaNet)
library(igraph)
#create a graph
sig = sigmaFromIgraph(lesMis)

# what the default values should be
betweenness(lesMis)
# values currently used by addNodeSize()
betweenness(graph_from_data_frame(sig$x$graph$edges))
# putting directed = FALSE in gets back to what I think the expected result should be
betweenness(graph_from_data_frame(sig$x$graph$edges, directed = FALSE))
```

I don't know if you're planning on dealing with directed networks (or give users the option to) but I hope this helps.