### PR TITLE
Node order missing

### DIFF
--- a/R/sigmaAttrs.R
+++ b/R/sigmaAttrs.R
@@ -121,8 +121,9 @@ addNodeSize <- function(sigmaObj, minSize = 1, maxSize = 3, sizeMetric = 'degree
     sigmaObj$x$options$minNodeSize <- minSize
     sigmaObj$x$options$maxNodeSize <- maxSize
   } else{
-    tmp_graph <- igraph::graph_from_data_frame(sigmaObj$x$graph$edges,
-                                               directed = FALSE)
+    tmp_graph <- igraph::graph_from_data_frame(d = edges,
+                                               directed = FALSE,
+                                               vertices = nodes$id)
     if(sizeMetric == 'degree'){
       nodes$size <- igraph::degree(tmp_graph)
     } else if(sizeMetric == 'closeness'){


### PR DESCRIPTION
…h no edges.

This is an updated version of #17 

### What my pull fixes (if applicable)
#15 

### What my pull improves (if applicable)
It allows nodes to have no connections. As these don't appear in the edges data frame they won't be created in `tmp_graph`.

### Confirmation that you have tested your code
Example of test code below, although I have also used other graphs. There can be small rounding errors but I haven't had any mismatches down to 10^(-12).

```{r}
library(sigmaNet)
library(igraph)

data = lesMis

sigmaObj = sigmaFromIgraph(data)

# code from addNodeSize()
edges <- jsonlite::fromJSON(sigmaObj$x$data)$edges
nodes <- jsonlite::fromJSON(sigmaObj$x$data)$nodes

tmp_graph <- igraph::graph_from_data_frame(d = edges,
                                                                           directed = FALSE,
                                                                           vertices = nodes$id)
nodes$size <- igraph::betweenness(tmp_graph)
table(abs(igraph::betweenness(data) - nodes$size) < 1e-12)
```
